### PR TITLE
Give access to upgrade data

### DIFF
--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -172,6 +172,27 @@ describe HTTP::Parser do
     @done.should be_true
   end
 
+  it 'sets upgrade_data if available' do
+    @parser <<
+      "GET /demo HTTP/1.1\r\n" +
+      "Connection: Upgrade\r\n" +
+      "Upgrade: WebSocket\r\n\r\n" +
+      "third key data"
+
+    @parser.upgrade?.should be_true
+    @parser.upgrade_data.should == 'third key data'
+  end
+
+  it 'sets upgrade_data to blank if un-available' do
+    @parser <<
+      "GET /demo HTTP/1.1\r\n" +
+      "Connection: Upgrade\r\n" +
+      "Upgrade: WebSocket\r\n\r\n"
+
+    @parser.upgrade?.should be_true
+    @parser.upgrade_data.should == ''
+  end
+
   %w[ request response ].each do |type|
     JSON.parse(File.read(File.expand_path("../support/#{type}s.json", __FILE__))).each do |test|
       test['headers'] ||= {}
@@ -181,7 +202,6 @@ describe HTTP::Parser do
 
         @parser.keep_alive?.should == test['should_keep_alive']
         @parser.upgrade?.should == (test['upgrade']==1)
-        @parser.upgrade_data.should == test['upgrade_data'] if (test['upgrade']==1)
         @parser.http_method.should == test['method']
 
         fields = %w[

--- a/spec/support/requests.json
+++ b/spec/support/requests.json
@@ -315,7 +315,7 @@
   {
     "name": "upgrade request",
     "type": "HTTP_REQUEST",
-    "raw": "GET /demo HTTP/1.1\r\nHost: example.com\r\nConnection: Upgrade\r\nSec-WebSocket-Key2: 12998 5 Y3 1  .P00\r\nSec-WebSocket-Protocol: sample\r\nUpgrade: WebSocket\r\nSec-WebSocket-Key1: 4 @1  46546xW%0l 1 5\r\nOrigin: http://example.com\r\n\r\nthird key data",
+    "raw": "GET /demo HTTP/1.1\r\nHost: example.com\r\nConnection: Upgrade\r\nSec-WebSocket-Key2: 12998 5 Y3 1  .P00\r\nSec-WebSocket-Protocol: sample\r\nUpgrade: WebSocket\r\nSec-WebSocket-Key1: 4 @1  46546xW%0l 1 5\r\nOrigin: http://example.com\r\n\r\n",
     "should_keep_alive": true,
     "message_complete_on_eof": false,
     "http_major": 1,
@@ -327,7 +327,6 @@
     "request_url": "/demo",
     "num_headers": 7,
     "upgrade": 1,
-    "upgrade_data": "third key data",
     "headers": {
       "Host": "example.com",
       "Connection": "Upgrade",
@@ -354,7 +353,6 @@
     "request_url": "home0.netscape.com:443",
     "num_headers": 2,
     "upgrade": 1,
-    "upgrade_data" : "",
     "headers": {
       "User-agent": "Mozilla/1.1N",
       "Proxy-authorization": "basic aGVsbG86d29ybGQ="


### PR DESCRIPTION
If the parser detects the request is an upgrade it will stop processing after the headers. This pulls out any upgrade data that was in the request and makes it available from the parser through parser.upgrade_data.
