### PR TITLE
reset support for requests with no body

### DIFF
--- a/ext/ruby_http_parser/ruby_http_parser.c
+++ b/ext/ruby_http_parser/ruby_http_parser.c
@@ -100,6 +100,7 @@ static ID Ion_body;
 static ID Ion_message_complete;
 
 static VALUE Sstop;
+static VALUE Sreset;
 static VALUE Sarrays;
 static VALUE Sstrings;
 static VALUE Smixed;
@@ -229,6 +230,8 @@ int on_headers_complete(ryah_http_parser *parser) {
   if (ret == Sstop) {
     wrapper->stopped = Qtrue;
     return -1;
+  } else if (ret == Sreset){
+    return 1;
   } else {
     return 0;
   }
@@ -502,6 +505,7 @@ void Init_ruby_http_parser() {
   Ion_body = rb_intern("on_body");
   Ion_message_complete = rb_intern("on_message_complete");
   Sstop = ID2SYM(rb_intern("stop"));
+  Sreset = ID2SYM(rb_intern("reset"));
 
   Sarrays = ID2SYM(rb_intern("arrays"));
   Sstrings = ID2SYM(rb_intern("strings"));


### PR DESCRIPTION
:reset support for on_headers_complete to deal with responses which have no body (ex HEAD)

this is a documented feature in the parser, but missing in the ruby wrapper:
https://github.com/joyent/http-parser/blob/c0ecab0516147401b5fd02a2272ebfb5dce8deb4/http_parser.h#L74-78

This is to enable pipelining support for head requests: https://github.com/igrigorik/em-http-request/issues/99
