### PR TITLE
Gem installation fails with space in path

### DIFF
--- a/ext/ruby_http_parser/extconf.rb
+++ b/ext/ruby_http_parser/extconf.rb
@@ -18,7 +18,5 @@ src_dir = File.expand_path('../', __FILE__)
   }
 end
 
-$CFLAGS << " -I#{src_dir}"
-
 dir_config("ruby_http_parser")
 create_makefile("ruby_http_parser")


### PR DESCRIPTION
When I try and install the gem into a path that contains spaces, it fails with the following:

```
Installing http_parser.rb (0.5.3) with native extensions 
Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.

        /Users/blake/.rbenv/versions/1.9.3-p194/bin/ruby extconf.rb 
creating Makefile

make
Makefile:170: warning: overriding commands for target `/Users/blake/Projects/test'
Makefile:161: warning: ignoring old commands for target `/Users/blake/Projects/test'
compiling ruby_http_parser.c
i686-apple-darwin11-llvm-gcc-4.2: project/vendor/gems/ruby/1.9.1/gems/http_parser.rb-0.5.3/ext/ruby_http_parser: No such file or directory
ruby_http_parser.c: In function ‘on_message_begin’:
ruby_http_parser.c:120: warning: ISO C90 forbids mixed declarations and code
ruby_http_parser.c: In function ‘on_header_value’:
ruby_http_parser.c:176: warning: ISO C90 forbids mixed declarations and code
ruby_http_parser.c: In function ‘on_headers_complete’:
ruby_http_parser.c:222: warning: ISO C90 forbids mixed declarations and code
ruby_http_parser.c: In function ‘on_body’:
ruby_http_parser.c:243: warning: ISO C90 forbids mixed declarations and code
ruby_http_parser.c: In function ‘on_message_complete’:
ruby_http_parser.c:262: warning: ISO C90 forbids mixed declarations and code
ruby_http_parser.c: In function ‘Parser_execute’:
ruby_http_parser.c:343: warning: ISO C90 forbids mixed declarations and code
ruby_http_parser.c:349: warning: ISO C90 forbids mixed declarations and code
ruby_http_parser.c: In function ‘Parser_set_header_value_type’:
ruby_http_parser.c:480: warning: ISO C90 forbids mixed declarations and code
make: *** [ruby_http_parser.o] Error 1


Gem files will remain installed in /Users/blake/Projects/test project/vendor/gems/ruby/1.9.1/gems/http_parser.rb-0.5.3 for inspection.
Results logged to /Users/blake/Projects/test project/vendor/gems/ruby/1.9.1/gems/http_parser.rb-0.5.3/ext/ruby_http_parser/gem_make.out
An error occured while installing http_parser.rb (0.5.3), and Bundler cannot continue.
Make sure that `gem install http_parser.rb -v '0.5.3'` succeeds before bundling.
```
