### PR TITLE
Fix 1.9 encoding issues on jruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,8 @@ GEM
     diff-lcs (1.1.2)
     ffi (1.0.11)
     ffi (1.0.11-java)
-    json (1.5.1)
-    json (1.5.1-java)
+    json (1.8.0)
+    json (1.8.0-java)
     rake (0.9.2)
     rake-compiler (0.7.9)
       rake


### PR DESCRIPTION
This fixes the `utf-8 path request` in `spec/support/requests.json`. Plus it should fix all the other string encoding issues on jruby in 1.9 mode.

I had to update json because the old version didn't handle utf-8 correctly on jruby. 
