### PR TITLE
Follow rspec option name change and use long option

### DIFF
--- a/tasks/spec.rake
+++ b/tasks/spec.rake
@@ -1,5 +1,5 @@
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new do |t|
-  t.rspec_opts = %w(-fs -c)
+  t.rspec_opts = %w(--format documentation --color)
 end


### PR DESCRIPTION
Unless applying this patch, rspec complains as follows:

```log
 $ bundle exec rake spec
/Users/hhatake/.rbenv/versions/2.4.0-preview3/bin/ruby -I/Users/hhatake/Github/http_parser.rb/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.5.4/lib:/Users/hhatake/Github/http_parser.rb/vendor/bundle/ruby/2.4.0/gems/rspec-support-3.5.0/lib /Users/hhatake/Github/http_parser.rb/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.5.4/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb -fs -c
/Users/hhatake/Github/http_parser.rb/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/formatters.rb:173:in `find_formatter': Formatter 's' unknown - maybe you meant 'documentation' or 'progress'?. (ArgumentError)
	from /Users/hhatake/Github/http_parser.rb/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/formatters.rb:141:in `add'
	from /Users/hhatake/Github/http_parser.rb/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:828:in `add_formatter'
	from /Users/hhatake/Github/http_parser.rb/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:117:in `block in load_formatters_into'
	from /Users/hhatake/Github/http_parser.rb/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:117:in `each'
	from /Users/hhatake/Github/http_parser.rb/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:117:in `load_formatters_into'
	from /Users/hhatake/Github/http_parser.rb/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:23:in `configure'
	from /Users/hhatake/Github/http_parser.rb/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:99:in `setup'
	from /Users/hhatake/Github/http_parser.rb/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:86:in `run'
	from /Users/hhatake/Github/http_parser.rb/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
	from /Users/hhatake/Github/http_parser.rb/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
	from /Users/hhatake/Github/http_parser.rb/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<main>'
/Users/hhatake/.rbenv/versions/2.4.0-preview3/bin/ruby -I/Users/hhatake/Github/http_parser.rb/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.5.4/lib:/Users/hhatake/Github/http_parser.rb/vendor/bundle/ruby/2.4.0/gems/rspec-support-3.5.0/lib /Users/hhatake/Github/http_parser.rb/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.5.4/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb -fs -c failed
```