### PR TITLE
Git submodules cannot be checked out if 9418 is blocked

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "http-parser"]
 	path = ext/ruby_http_parser/vendor/http-parser
-	url = git://github.com/nodejs/http-parser.git
+	url = https://github.com/nodejs/http-parser.git
 [submodule "http-parser-java"]
 	path = ext/ruby_http_parser/vendor/http-parser-java
-	url = git://github.com/tmm1/http-parser.java
+	url = https://github.com/tmm1/http-parser.java


### PR DESCRIPTION
It seems that some mastodon users run into issues during the submodule checkout:

https://github.com/tootsuite/mastodon/issues/7607

https://github.com/bundler/bundler/issues/6551

Would that be possible to just use https: instead?