### PR TITLE
CI: Add 2.5, 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,7 @@ rvm:
 - 2.4
 - 2.5
 - 2.6
+- jruby-9.2.6.0
+env:
+  global:
+    - JRUBY_OPTS=--debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 rvm:
 - 2.0
@@ -6,3 +5,5 @@ rvm:
 - 2.2
 - 2.3
 - 2.4
+- 2.5
+- 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
 - 2.4
 - 2.5
 - 2.6
-- jruby-9.2.6.0
+- jruby-9.2.7.0
 env:
   global:
     - JRUBY_OPTS=--debug

--- a/tasks/compile.rake
+++ b/tasks/compile.rake
@@ -12,6 +12,8 @@ end
 if RUBY_PLATFORM =~ /java/
   Rake::JavaExtensionTask.new("ruby_http_parser", gemspec) do |ext|
     ext.classpath = File.expand_path('../../ext/ruby_http_parser/vendor/http-parser-java/ext/primitives.jar', __FILE__)
+    ext.source_version = '1.8'
+    ext.target_version = '1.8'
   end
 else
   Rake::ExtensionTask.new("ruby_http_parser", gemspec) do |ext|


### PR DESCRIPTION
This PR extends the **CI matrix, adding 2.5, 2.6**.

Travis option removed: See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration for historical detail about when `sudo: false` was removed.

