### PR TITLE
Check value passed to set_header_value_type

### DIFF
--- a/ext/ruby_http_parser/org/ruby_http_parser/RubyHttpParser.java
+++ b/ext/ruby_http_parser/org/ruby_http_parser/RubyHttpParser.java
@@ -8,6 +8,9 @@ import http_parser.lolevel.HTTPDataCallback;
 import http_parser.lolevel.ParserSettings;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.jcodings.Encoding;
 import org.jcodings.specific.UTF8Encoding;
@@ -81,6 +84,10 @@ public class RubyHttpParser extends RubyObject {
   private byte[] _last_header;
 
   private static final Encoding UTF8 = UTF8Encoding.INSTANCE;
+
+  private static final List<String> VALUE_TYPES = new ArrayList<String>(
+    Arrays.asList("mixed", "arrays", "strings")
+  );
 
   public RubyHttpParser(final Ruby runtime, RubyClass clazz) {
     super(runtime, clazz);
@@ -495,7 +502,7 @@ public class RubyHttpParser extends RubyObject {
   @JRubyMethod(name = "header_value_type=")
   public IRubyObject set_header_value_type(IRubyObject val) {
     String valString = val.toString();
-    if (valString != "mixed" && valString != "arrays" && valString != "strings") {
+    if (!VALUE_TYPES.contains(valString)) {
       throw runtime.newArgumentError("Invalid header value type");
     }
     header_value_type = val;


### PR DESCRIPTION
The details of the change are given in the commit message.

I'm requesting this change because a user of Faye is having trouble on JRuby 9.2. Faye depends on em-http-request, which uses http_parser.rb. On this line, it calls into `set_header_value_type` in the Java implementation:

https://github.com/igrigorik/em-http-request/blob/v1.1.5/lib/em-http/http_connection.rb#L115

This worked on JRuby 1.7 but not on 9.2, so this method always fails to accept the given argument, even if it should be valid, and this means we cannot make HTTP requests.

Here's the relevant Faye issue: https://github.com/faye/faye/issues/502