### PR TITLE
Make this library ractor-safe

### DIFF
--- a/ext/ruby_http_parser/ruby_http_parser.c
+++ b/ext/ruby_http_parser/ruby_http_parser.c
@@ -489,6 +489,10 @@ VALUE Parser_reset(VALUE self) {
 }
 
 void Init_ruby_http_parser() {
+#ifdef HAVE_RB_EXT_RACTOR_SAFE
+  rb_ext_ractor_safe(true);
+#endif
+
   VALUE mHTTP = rb_define_module("HTTP");
   cParser = rb_define_class_under(mHTTP, "Parser", rb_cObject);
   cRequestParser = rb_define_class_under(mHTTP, "RequestParser", cParser);

--- a/ext/ruby_http_parser/ruby_http_parser.c
+++ b/ext/ruby_http_parser/ruby_http_parser.c
@@ -318,7 +318,7 @@ VALUE Parser_initialize(int argc, VALUE *argv, VALUE self) {
 
   VALUE default_header_value_type = Qnil;
 
-  if (RB_TYPE_P(argv[argc-1], T_HASH)) {
+  if (argc > 0 && RB_TYPE_P(argv[argc-1], T_HASH)) {
     static ID keyword_ids[1];
 
     if (!keyword_ids[0]) {

--- a/ext/ruby_http_parser/ruby_http_parser.c
+++ b/ext/ruby_http_parser/ruby_http_parser.c
@@ -316,7 +316,7 @@ VALUE Parser_initialize(int argc, VALUE *argv, VALUE self) {
   ParserWrapper *wrapper = NULL;
   DATA_GET(self, ParserWrapper, wrapper);
 
-  wrapper->header_value_type = rb_iv_get(CLASS_OF(self), "@default_header_value_type");
+  VALUE default_keyword_value_type = Qnil;
 
   if (argc == 1) {
     wrapper->callback_object = argv[0];
@@ -324,7 +324,13 @@ VALUE Parser_initialize(int argc, VALUE *argv, VALUE self) {
 
   if (argc == 2) {
     wrapper->callback_object = argv[0];
-    wrapper->header_value_type = argv[1];
+    default_keyword_value_type = argv[1];
+  }
+
+  if (default_keyword_value_type == Qnil) {
+    wrapper->header_value_type = rb_iv_get(CLASS_OF(self), "@default_header_value_type");
+  } else {
+    wrapper->header_value_type = default_keyword_value_type;
   }
 
   return self;

--- a/ext/ruby_http_parser/ruby_http_parser.c
+++ b/ext/ruby_http_parser/ruby_http_parser.c
@@ -318,6 +318,19 @@ VALUE Parser_initialize(int argc, VALUE *argv, VALUE self) {
 
   VALUE default_keyword_value_type = Qnil;
 
+  if (RB_TYPE_P(argv[argc-1], T_HASH)) {
+    static ID keyword_ids[1];
+
+    if (!keyword_ids[0]) {
+      keyword_ids[0] = rb_intern("default_header_value_type");
+    }
+    rb_get_kwargs(argv[argc-1], keyword_ids, 0, 1, &default_keyword_value_type);
+    if (default_keyword_value_type == Qundef) {
+      default_keyword_value_type = Qnil;
+    }
+    --argc;
+  }
+
   if (argc == 1) {
     wrapper->callback_object = argv[0];
   }

--- a/ext/ruby_http_parser/ruby_http_parser.c
+++ b/ext/ruby_http_parser/ruby_http_parser.c
@@ -319,11 +319,8 @@ VALUE Parser_initialize(int argc, VALUE *argv, VALUE self) {
   VALUE default_header_value_type = Qnil;
 
   if (argc > 0 && RB_TYPE_P(argv[argc-1], T_HASH)) {
-    static ID keyword_ids[1];
-
-    if (!keyword_ids[0]) {
-      keyword_ids[0] = rb_intern("default_header_value_type");
-    }
+    ID keyword_ids[1];
+    keyword_ids[0] = rb_intern("default_header_value_type");
     rb_get_kwargs(argv[argc-1], keyword_ids, 0, 1, &default_header_value_type);
     if (default_header_value_type == Qundef) {
       default_header_value_type = Qnil;

--- a/ext/ruby_http_parser/ruby_http_parser.c
+++ b/ext/ruby_http_parser/ruby_http_parser.c
@@ -316,7 +316,7 @@ VALUE Parser_initialize(int argc, VALUE *argv, VALUE self) {
   ParserWrapper *wrapper = NULL;
   DATA_GET(self, ParserWrapper, wrapper);
 
-  VALUE default_keyword_value_type = Qnil;
+  VALUE default_header_value_type = Qnil;
 
   if (RB_TYPE_P(argv[argc-1], T_HASH)) {
     static ID keyword_ids[1];
@@ -324,9 +324,9 @@ VALUE Parser_initialize(int argc, VALUE *argv, VALUE self) {
     if (!keyword_ids[0]) {
       keyword_ids[0] = rb_intern("default_header_value_type");
     }
-    rb_get_kwargs(argv[argc-1], keyword_ids, 0, 1, &default_keyword_value_type);
-    if (default_keyword_value_type == Qundef) {
-      default_keyword_value_type = Qnil;
+    rb_get_kwargs(argv[argc-1], keyword_ids, 0, 1, &default_header_value_type);
+    if (default_header_value_type == Qundef) {
+      default_header_value_type = Qnil;
     }
     --argc;
   }
@@ -337,13 +337,13 @@ VALUE Parser_initialize(int argc, VALUE *argv, VALUE self) {
 
   if (argc == 2) {
     wrapper->callback_object = argv[0];
-    default_keyword_value_type = argv[1];
+    default_header_value_type = argv[1];
   }
 
-  if (default_keyword_value_type == Qnil) {
+  if (default_header_value_type == Qnil) {
     wrapper->header_value_type = rb_iv_get(CLASS_OF(self), "@default_header_value_type");
   } else {
-    wrapper->header_value_type = default_keyword_value_type;
+    wrapper->header_value_type = default_header_value_type;
   }
 
   return self;


### PR DESCRIPTION
As [documented here](https://github.com/ruby/ruby/blob/master/doc/extension.rdoc#label-Appendix+F.+Ractor+support), we need to mark libraries ractor-safe if we want to call C extension methods in Ractor.
This change is to update this library ractor-safe by:
* marking methods as ractor-safe
* avoid referring a class instance variable if not needed (if a default header value type is specified)

Adding a keyword argument `default_header_value_type` is to avoid writing `Http::Parser.new(nil, type)` always (in Ractor) by using a keyword argument.
I'm ok to remove it if it's not @tmm1 's way.