### PR TITLE
Replace obsolete File.exists? with File exist?

### DIFF
--- a/tasks/compile.rake
+++ b/tasks/compile.rake
@@ -34,7 +34,7 @@ RUBY_VERSION =~ /(\\d+.\\d+)/
 require "\#{$1}/ruby_http_parser"
     eoruby
   end
-  at_exit{ FileUtils.rm t.name if File.exists?(t.name) }
+  at_exit{ FileUtils.rm t.name if File.exist?(t.name) }
 end
 
 if Rake::Task.task_defined?(:cross)


### PR DESCRIPTION
File.exists? has been removed as of Ruby 3.2:
https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/

Signed-off-by: Takuro Ashie <ashie@clear-code.com>