### PR TITLE
Add missing Ruby 3.3/3.4 for CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3', '3.4' ]
         os: [ 'ubuntu-latest' ]
     name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }}
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3', '3.4' ]
+        ruby: [ '3.1', '3.2', '3.3', '3.4' ]
         os: [ 'ubuntu-latest' ]
     name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }}
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ 'ubuntu-latest' ]
     name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3', '3.4' ]
         os: [ 'windows-latest' ]
     name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }}
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3', '3.4' ]
+        ruby: [ '3.1', '3.2', '3.3', '3.4' ]
         os: [ 'windows-latest' ]
     name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }}
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ 'windows-latest' ]
     name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
* Add missing Ruby 3.3/3.4 for CI
* ci: Use latest actions/checkout@v4 for CI
